### PR TITLE
Correct Cleanup when ScriBt exits

### DIFF
--- a/ROM.sh
+++ b/ROM.sh
@@ -75,6 +75,10 @@ function exitScriBt() # ID
     echo -e "\n${SCS:-[:)]} Thanks for using ScriBt.\n";
     [[ "$1" == "0" ]] && echo -e "${CL_LGN}[${NONE}${CL_LRD}<3${NONE}${CL_LGN}]${NONE} Peace! :)\n" ||\
         echo -e "${CL_LRD}[${NONE}${CL_RED}<${NONE}${CL_LGR}/${NONE}${CL_RED}3${NONE}${CL_LRD}]${NONE} Failed somewhere :(\n";
+    rm temp_v1.txt temp_v2.txt temp.txt
+    [ -s temp_sync.txt ] || rm temp_sync.txt # If temp_sync.txt is empty, delete it
+    [ -s temp_compile.txt ] || rm temp_compile.txt # If temp_compile.txt is empty, delete it
+    [ -f ROM.sh ] || rm upScriBt.sh # Assume we are not in the ScriBt directory if ROM.sh does not exist, so delete upScriBt.sh
     exit $1;
 } # exitScriBt
 

--- a/ROM.sh
+++ b/ROM.sh
@@ -78,7 +78,6 @@ function exitScriBt() # ID
     rm temp_v1.txt temp_v2.txt temp.txt
     [ -s temp_sync.txt ] || rm temp_sync.txt # If temp_sync.txt is empty, delete it
     [ -s temp_compile.txt ] || rm temp_compile.txt # If temp_compile.txt is empty, delete it
-    [ -f ROM.sh ] || rm upScriBt.sh # Assume we are not in the ScriBt directory if ROM.sh does not exist, so delete upScriBt.sh
     exit $1;
 } # exitScriBt
 

--- a/ROM.sh
+++ b/ROM.sh
@@ -75,9 +75,9 @@ function exitScriBt() # ID
     echo -e "\n${SCS:-[:)]} Thanks for using ScriBt.\n";
     [[ "$1" == "0" ]] && echo -e "${CL_LGN}[${NONE}${CL_LRD}<3${NONE}${CL_LGN}]${NONE} Peace! :)\n" ||\
         echo -e "${CL_LRD}[${NONE}${CL_RED}<${NONE}${CL_LGR}/${NONE}${CL_RED}3${NONE}${CL_LRD}]${NONE} Failed somewhere :(\n";
-    rm temp_v1.txt temp_v2.txt temp.txt
-    [ -s temp_sync.txt ] || rm temp_sync.txt # If temp_sync.txt is empty, delete it
-    [ -s temp_compile.txt ] || rm temp_compile.txt # If temp_compile.txt is empty, delete it
+    rm ${CALL_ME_ROOT}temp_v1.txt ${CALL_ME_ROOT}temp_v2.txt ${CALL_ME_ROOT}temp.txt
+    [ -s ${CALL_ME_ROOT}temp_sync.txt ] || rm ${CALL_ME_ROOT}temp_sync.txt # If temp_sync.txt is empty, delete it
+    [ -s ${CALL_ME_ROOT}temp_compile.txt ] || rm ${CALL_ME_ROOT}temp_compile.txt # If temp_compile.txt is empty, delete it
     exit $1;
 } # exitScriBt
 
@@ -1460,9 +1460,9 @@ function the_start() # 0
         exitScriBt 1;
     fi
     #   tempfile      repo sync log       rom build log        vars b4 exe     vars after exe
-    TMP=temp.txt; STMP=temp_sync.txt; RMTMP=temp_compile.txt; TV1=temp_v1.txt; TV2=temp_v2.txt;
-    rm -rf temp{,_sync,_compile,_v{1,2}}.txt;
-    touch temp{,_sync,_compile,_v{1,2}}.txt;
+    TMP=${CALL_ME_ROOT}temp.txt; STMP=${CALL_ME_ROOT}temp_sync.txt; RMTMP=${CALL_ME_ROOT}temp_compile.txt; TV1=${CALL_ME_ROOT}temp_v1.txt; TV2=${CALL_ME_ROOT}temp_v2.txt;
+    rm -rf ${CALL_ME_ROOT}temp{,_sync,_compile,_v{1,2}}.txt;
+    touch ${CALL_ME_ROOT}temp{,_sync,_compile,_v{1,2}}.txt;
     ATBT="${CL_WYT}*${NONE}${CL_LRD}AutoBot${NONE}${CL_WYT}*${NONE}";
     # CHEAT CHEAT CHEAT!
     if [ -z "$automate" ]; then


### PR DESCRIPTION
 - Always delete temp.txt, temp_v1.txt and temp_v2.txt
 - Delete temp_sync.txt if it's empty
 - Delete temp_compile.txt if it's empty
 - Delete upScriBt.sh if not in ScriBt directory

Linked to Issue (#19)